### PR TITLE
Add temp fix for images

### DIFF
--- a/example.es6
+++ b/example.es6
@@ -10,7 +10,7 @@ export default (
     flytitle={article.attributes.flytitle}
     rubric={article.attributes.rubric}
     mainImage={{
-      src: article.attributes.mainimage,
+      src: article.attributes.mainimage.src,
       alt: article.attributes.imagealt,
     }}
     content={article.attributes.content}

--- a/header.es6
+++ b/header.es6
@@ -76,8 +76,7 @@ export class WinHeader extends Component {
       mainImageEl = (
         <img
           className={generateClassNameList('ArticleTemplate--image').join(' ')}
-          src={`${mainImage.src['1.0x']}`}
-          srcSet={getSrcSet(mainImage.src)}
+          src={`${mainImage.src}`}
           alt={mainImage.alt}
           itemProp="image"
         />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-win-articlepage",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Display an article with the world-in articletemplate",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",

--- a/test/data/article.json
+++ b/test/data/article.json
@@ -54,13 +54,7 @@
     ],
     "section": "Politics",
     "mainimage": {
-      "1.0x": "/example-assets/1cab46323bec@1x.jpg",
-      "1.3x": "/example-assets/1cab46323bec@1.3x.jpg",
-      "1.4x": "/example-assets/1cab46323bec@1.4x.jpg",
-      "1.6x": "/example-assets/1cab46323bec@1.6x.jpg",
-      "2.0x": "/example-assets/1cab46323bec@2x.jpg",
-      "2.6x": "/example-assets/1cab46323bec@2.6x.jpg",
-      "3.3x": "/example-assets/1cab46323bec@3.3x.jpg"
+      "src": "http://cms-worldin.economist.com/sites/default/files/styles/base_leader__max-width_480_/public/20151119_EUP007_1190x967.jpg?itok=AFwB7A2_"
     },
     "tileimage": {
       "1.0x": "/example-assets/19c0e5b43e9e@1x.jpg",


### PR DESCRIPTION
Image is currently looking for a src set but our api is temporarily only returning a single image and not a set of images. This is a temp fix to the article page so it uses the single image supplied.