### PR TITLE
Initial 'world-in-numbers' and Country support

### DIFF
--- a/body.es6
+++ b/body.es6
@@ -2,10 +2,21 @@ import ArticleBodyTemplate from '@economist/component-articletemplate/body';
 import AdvertisementPanel from '@economist/component-ad-panel';
 import ImageCaption from '@economist/component-imagecaption';
 import Video from '@economist/component-video';
+import Country from '@economist/component-win-country';
+
 import { createVariant } from '@economist/component-variantify';
 
-export default createVariant({
+const innerArticleBodyComponents = {
   AdvertisementPanel,
   ImageCaption,
   Video,
+};
+
+const StandardArticleBody = createVariant(
+  innerArticleBodyComponents
+)(ArticleBodyTemplate);
+const WorldInNumbersArticleBody = createVariant({
+  ...innerArticleBodyComponents,
+  Country,
 })(ArticleBodyTemplate);
+export { StandardArticleBody, WorldInNumbersArticleBody };

--- a/body.es6
+++ b/body.es6
@@ -2,7 +2,7 @@ import ArticleBodyTemplate from '@economist/component-articletemplate/body';
 import AdvertisementPanel from '@economist/component-ad-panel';
 import ImageCaption from '@economist/component-imagecaption';
 import Video from '@economist/component-video';
-import Country from '@economist/component-win-country';
+import { Country } from '@economist/component-win-stats-container';
 
 import { createVariant } from '@economist/component-variantify';
 

--- a/example.es6
+++ b/example.es6
@@ -1,7 +1,7 @@
 import React from 'react';
 import WorldInArticle from '.';
 import article from './test/data/article';
-// import article from './test/data/world-in-numbers-article-large';
+// There is also sample data for world-in-numbers within './test/data/'
 
 export default (
   <WorldInArticle

--- a/example.es6
+++ b/example.es6
@@ -1,6 +1,7 @@
 import React from 'react';
 import WorldInArticle from '.';
-import article from './test/data/article';
+// import article from './test/data/article';
+import article from './test/data/world-in-numbers-article-large';
 
 export default (
   <WorldInArticle
@@ -16,5 +17,6 @@ export default (
     mainImage={article.attributes.mainimage}
     content={article.attributes.content}
     sectionName={article.attributes.section}
+    variantName={article.attributes.variantName}
   />
 );

--- a/example.es6
+++ b/example.es6
@@ -1,7 +1,7 @@
 import React from 'react';
 import WorldInArticle from '.';
-// import article from './test/data/article';
-import article from './test/data/world-in-numbers-article-large';
+import article from './test/data/article';
+// import article from './test/data/world-in-numbers-article-large';
 
 export default (
   <WorldInArticle

--- a/footer.es6
+++ b/footer.es6
@@ -1,3 +1,4 @@
+/* eslint react/no-multi-comp: 0 */
 import React, { Component, PropTypes } from 'react';
 
 import { ArticleFooterContainer } from '@economist/component-articletemplate/footer';
@@ -44,7 +45,7 @@ export class WinFooter extends Component {
       generateClassNameList: defaultGenerateClassNameList,
     };
   }
-  /* eslint-disable react/no-danger */
+
   render() {
     const { generateClassNameList, byline, bylineLocation, bio } = this.props;
     return (
@@ -72,7 +73,7 @@ export class WinFooter extends Component {
               ...generateClassNameList(`ArticleTemplate--byline-bio`),
               ...extendedFooterBylineDetailsClasses,
             ].join(' ')}
-            dangerouslySetInnerHTML={{
+            dangerouslySetInnerHTML={{ // eslint-disable-line react/no-danger
               '__html': bio,
             }}
           />
@@ -80,5 +81,5 @@ export class WinFooter extends Component {
       </ArticleFooterContainer>
     );
   }
-  /* eslint-enable react/no-danger */
+
 }

--- a/header.es6
+++ b/header.es6
@@ -2,7 +2,6 @@
 import React, { Component, PropTypes } from 'react';
 
 import { defaultGenerateClassNameList } from '@economist/component-variantify';
-import { getSrcSet } from '@economist/component-articletemplate/utils';
 import { isImage } from '@economist/component-articletemplate/proptypes';
 import Picture from '@economist/component-picture';
 
@@ -33,7 +32,7 @@ export class WinHeader extends Component {
   render() {
     const { generateClassNameList, mainImage, flytitle, title, rubric } = this.props;
 
-    let flytitleEl, titleEl, rubricEl, mainImageEl;
+    let flytitleEl = null, titleEl = null, rubricEl = null, mainImageEl = null;
     if (flytitle) {
       flytitleEl = (
         <h1
@@ -53,7 +52,7 @@ export class WinHeader extends Component {
           itemProp="alternativeHeadline"
           className={[
             ...generateClassNameList('ArticleTemplate--title'),
-            ...extendedHeaderItemClasses
+            ...extendedHeaderItemClasses,
           ].join(' ')}
         >
           {title}
@@ -66,7 +65,7 @@ export class WinHeader extends Component {
           itemProp="rubric"
           className={[
             ...generateClassNameList('ArticleTemplate--rubric'),
-            ...extendedHeaderItemClasses
+            ...extendedHeaderItemClasses,
           ].join(' ')}
         >
           {rubric}
@@ -118,14 +117,14 @@ export class WinPredictorsHeader extends Component {
   render() {
     const { generateClassNameList, mainImage, flytitle, title, rubric } = this.props;
 
-    let flytitleEl, titleEl, rubricEl, mainImageEl;
+    let flytitleEl = null, titleEl = null, rubricEl = null, mainImageEl = null;
     if (flytitle) {
       flytitleEl = (
         <h1
           itemProp="headline"
           className={[
             ...generateClassNameList('ArticleTemplate--flytitle'),
-            ...extendedHeaderItemClasses
+            ...extendedHeaderItemClasses,
           ].join(' ')}
         >
           {flytitle}
@@ -138,7 +137,7 @@ export class WinPredictorsHeader extends Component {
           itemProp="alternativeHeadline"
           className={[
             ...generateClassNameList('ArticleTemplate--title'),
-            ...extendedHeaderItemClasses
+            ...extendedHeaderItemClasses,
           ].join(' ')}
         >
           {title}
@@ -151,7 +150,7 @@ export class WinPredictorsHeader extends Component {
           itemProp="rubric"
           className={[
             ...generateClassNameList('ArticleTemplate--rubric'),
-            ...extendedHeaderItemClasses
+            ...extendedHeaderItemClasses,
           ].join(' ')}
         >
           {rubric}

--- a/index.css
+++ b/index.css
@@ -2,6 +2,7 @@
 @import '@economist/component-picture';
 @import '@economist/component-ad-panel';
 @import '@economist/component-video';
+@import '@economist/component-win-country';
 
 @import "./shared";
 @import "./main";

--- a/index.css
+++ b/index.css
@@ -2,7 +2,7 @@
 @import '@economist/component-picture';
 @import '@economist/component-ad-panel';
 @import '@economist/component-video';
-@import '@economist/component-win-country';
+@import '@economist/component-win-stats-container';
 
 @import "./shared";
 @import "./main";

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
   "dependencies": {
     "@economist/component-ad-panel": "^1.1.0",
     "@economist/component-articletemplate": "^8.0.0",
-    "@economist/component-win-country": "^1.0.0",
+    "@economist/component-win-stats-container": "^1.0.0",
     "@economist/component-imagecaption": "^2.0.0",
     "@economist/component-picture": "^1.1.0",
     "@economist/component-variantify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
   "dependencies": {
     "@economist/component-ad-panel": "^1.1.0",
     "@economist/component-articletemplate": "^8.0.0",
+    "@economist/component-win-country": "^1.0.0",
     "@economist/component-imagecaption": "^2.0.0",
     "@economist/component-picture": "^1.1.0",
     "@economist/component-variantify": "^1.0.1",

--- a/prop-transforms.es6
+++ b/prop-transforms.es6
@@ -1,10 +1,11 @@
 function getNthParagraphIndex(paragraphLine, content) {
   let lastParagraphIndex = 0;
   let currentIndex = 0;
-  let nParagraph = paragraphLine - 1;
-  while (nParagraph-- && currentIndex++ < content.length) {
+  let nParagraph = paragraphLine;
+  while (nParagraph > 1 && currentIndex++ < content.length) {
     if (typeof content[currentIndex] === 'string') {
       lastParagraphIndex = currentIndex;
+      nParagraph--;
     }
   }
 

--- a/prop-transforms.es6
+++ b/prop-transforms.es6
@@ -1,7 +1,7 @@
 function getNthParagraphIndex(paragraphLine, content) {
   let lastParagraphIndex = 0;
   let currentIndex = 0;
-  let nParagraph = paragraphLine;
+  let nParagraph = paragraphLine - 1;
   while (nParagraph-- && currentIndex++ < content.length) {
     if (typeof content[currentIndex] === 'string') {
       lastParagraphIndex = currentIndex;

--- a/test/data/article.json
+++ b/test/data/article.json
@@ -89,6 +89,7 @@
     "slug": "what-if-russia-breaks-up-the-peril-beyond-putin",
     "dateline": "MOSCOW",
     "rubric": "The world rightly worries about the prospect of a Greater Russia. But a Lesser Russia could be just as troubling",
+    "variantName": "world-in-main",
     "content": [
       "UNDER Vladimir Putin’s presidency, Russia is seen in the outside world as an expansionist power trying to revise post-Soviet borders and rebuild an empire. But what if Russia itself—a country of nearly 200 nationalities that stretches across 11 time zones—is in danger of crumbling?",
       "It would not be the first time that Russia tried aggression and expansion as a defence against modernisation and by doing so undermined its own territorial integrity. In 1904, when Russia was on the verge of a revolution, Nicholas II attempted to stave off change by looking for national traitors and starting a small war with Japan. The war ended a year later in Russia’s defeat and 12 years later the tsarist Russian empire faded away in a few days. In 1979, as Communist rule struggled under the weight of its own contradictions, the Soviet Union invaded Afghanistan; 12 years later the Soviet Union collapsed just as suddenly.",

--- a/test/data/world-in-numbers-article-large.json
+++ b/test/data/world-in-numbers-article-large.json
@@ -1,0 +1,1399 @@
+{
+  "type": "posts",
+  "id": "2",
+  "publishDate": "2015-09-29T16:45:56.698Z",
+  "attributes": {
+    "metaTags": [
+      {
+        "property": "og:type",
+        "content": "article"
+      },
+      {
+        "property": "og:title",
+        "content": "Fake title"
+      },
+      {
+        "property": "og:description",
+        "content": "Fake description"
+      },
+      {
+        "property": "og:image",
+        "content": "https://placehold.it/1792x1008"
+      },
+      {
+        "property": "og:image:width",
+        "content": "1792"
+      },
+      {
+        "property": "og:image:height",
+        "content": "1008"
+      },
+      {
+        "property": "article:published_time",
+        "content": "2015-07-24T09:00:00.000Z"
+      },
+      {
+        "property": "article:modified_time",
+        "content": "2015-07-24T09:00:00.000Z"
+      },
+      {
+        "property": "article:section",
+        "content": "Fake section"
+      },
+      {
+        "property": "article:tag",
+        "content": "Fake tag"
+      },
+      {
+        "property": "article:tag",
+        "content": "Fake tag 2"
+      },
+      {
+        "name": "twitter:card",
+        "content": "summary_large_image"
+      }
+    ],
+    "section": "Fake section",
+    "mainimage": {
+      "sources": [
+        { "url": "https://placehold.it/1792x1008", "width": 896, "height": 504, "dppx": 2 },
+        { "url": "https://placehold.it/896x504", "width": 896, "height": 504, "dppx": 1 },
+        { "url": "https://placehold.it/1536x864", "width": 768, "height": 432, "dppx": 2 },
+        { "url": "https://placehold.it/768x432", "width": 768, "height": 432, "dppx": 1 },
+        { "url": "https://placehold.it/1280x720", "width": 640, "height": 360, "dppx": 2 },
+        { "url": "https://placehold.it/640x470", "width": 640, "height": 360, "dppx": 1 },
+        { "url": "https://placehold.it/1024x768", "width": 512, "height": 384, "dppx": 2 },
+        { "url": "https://placehold.it/512x384", "width": 512, "height": 384, "dppx": 1 },
+        { "url": "https://placehold.it/768x768", "width": 384, "height": 384, "dppx": 2 },
+        { "url": "https://placehold.it/384x288", "width": 384, "height": 384, "dppx": 1 },
+        { "url": "https://placehold.it/512x768", "width": 256, "height": 384, "dppx": 2 },
+        { "url": "https://placehold.it/256x384", "width": 256, "height": 384, "dppx": 1 }
+      ],
+      "alt": "this is the image description"
+    },
+    "tileimage": {
+      "1.0x": "/example-assets/19c0e5b43e9e@1x.jpg",
+      "1.3x": "/example-assets/19c0e5b43e9e@1.3x.jpg",
+      "1.4x": "/example-assets/19c0e5b43e9e@1.4x.jpg",
+      "1.6x": "/example-assets/19c0e5b43e9e@1.6x.jpg",
+      "2.0x": "/example-assets/19c0e5b43e9e@2x.jpg",
+      "2.6x": "/example-assets/19c0e5b43e9e@2.6x.jpg",
+      "3.3x": "/example-assets/19c0e5b43e9e@3.3x.jpg"
+    },
+    "title": "Fake title",
+    "toc": "Fake toc",
+    "flytitle": "Fake flytitle",
+    "byline": "Fake byline",
+    "byline_location": "Fake location",
+    "bio": "<strong>Fake name</strong>: fake role, <em>fake magazine</em>",
+    "slug": "fake-title",
+    "dateline": "Fake date",
+    "rubric": "Fake rubric",
+    "variantName": "world-in-numbers",
+    "content": [
+      "The first sentence",
+      "The second sentence",
+      "The third sentence",
+      "The fourth sentence",
+      "The fifth sentence",
+      "The sixth sentence",
+      "The seventh sentence",
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 1",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 2",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 3",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 4",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 5",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 6",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 7",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 8",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 9",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 10",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 11",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 12",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 13",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 14",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 15",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 16",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 17",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 18",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 19",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 20",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 21",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 22",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 23",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 24",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 25",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 26",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 27",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 28",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 29",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 30",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 31",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 32",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 33",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 34",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 35",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 36",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 37",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 38",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 39",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 40",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 41",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 42",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 43",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 44",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 45",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 46",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 47",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 48",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 49",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 50",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 51",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 52",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 53",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 54",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 55",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 56",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 57",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 58",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 59",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 60",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 61",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 62",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 63",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 64",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 65",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 66",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 67",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 68",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 69",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 70",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 71",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 72",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 73",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 74",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 75",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 76",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 77",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 78",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 79",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 80",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      },
+      {
+        "component": "Country",
+        "props": {
+          "title": "Country 81",
+          "stats": [
+            {
+              "key": "stat A",
+              "value": "value for stat A"
+            }
+          ]
+        },
+        "content": [
+          "The first line.",
+          "The second line."
+        ]
+      }
+    ]
+  }
+}

--- a/variant-article.es6
+++ b/variant-article.es6
@@ -4,7 +4,10 @@ import createVariantSwitcher from '@economist/component-variantify';
 
 import { WinHeader, WinPredictorsHeader } from './header';
 import { WinSubheader, WinLeaderSubheader } from './subheader';
-import WinArticleBody from './body';
+import {
+  StandardArticleBody as StandardWinArticleBody,
+  WorldInNumbersArticleBody as WorldInNumbersWinArticleBody,
+} from './body';
 import { WinFooter } from './footer';
 
 const config = {
@@ -13,28 +16,33 @@ const config = {
     'world-in-main': {
       ArticleHeader: WinHeader,
       ArticleSubheader: WinSubheader,
-      ArticleBody: WinArticleBody,
+      ArticleBody: StandardWinArticleBody,
       ArticleFooter: WinFooter,
     },
     'world-in-portrait': {
       ArticleHeader: WinHeader,
       ArticleSubheader: WinSubheader,
-      ArticleBody: WinArticleBody,
+      ArticleBody: StandardWinArticleBody,
       ArticleFooter: WinFooter,
     },
     'world-in-leader': {
       ArticleHeader: WinHeader,
       ArticleSubheader: WinLeaderSubheader,
-      ArticleBody: WinArticleBody,
+      ArticleBody: StandardWinArticleBody,
       ArticleFooter: WinFooter,
     },
     'world-in-predictors': {
+      ArticleHeader: WinPredictorsHeader,
+      ArticleSubheader: WinSubheader,
+      ArticleBody: StandardWinArticleBody,
+      ArticleFooter: WinFooter,
+    },
+    'world-in-numbers': {
       ArticleHeader: WinHeader,
       ArticleSubheader: WinSubheader,
-      ArticleBody: WinArticleBody,
+      ArticleBody: WorldInNumbersWinArticleBody,
       ArticleFooter: WinFooter,
     },
   },
 };
-
 export default createVariantSwitcher(config)(ArticleTemplate);


### PR DESCRIPTION
- [x] Uses `component-win-stats-container` if you are on a article that has a `variantName` of `world-in-numbers`.
- [x] [Fix advert placement](https://github.com/sebinsua/component-win-articlepage/commit/b96bc838d31f771f1a826b99b54e8a0c32cc5efe) so that non-strings are not counted as `paragraphLine`s.
- [x] Fix the  `world-in-predictors` article variant to use the header that was previously defined specifically for it.

Dependent on: https://github.com/economist-components/component-win-stats-container/pull/1