### PR TITLE
CSS updates to match design for world in numbers

### DIFF
--- a/header.es6
+++ b/header.es6
@@ -178,3 +178,52 @@ export class WinPredictorsHeader extends Component {
     );
   }
 }
+
+export class WinNumbersHeader extends Component {
+  static get propTypes() {
+    return {
+      generateClassNameList: PropTypes.func,
+    };
+  }
+
+  static get defaultProps() {
+    return {
+      generateClassNameList: defaultGenerateClassNameList,
+    };
+  }
+
+  render() {
+    const { generateClassNameList } = this.props;
+    const titleEl = (
+      <div>
+        <h1
+          itemProp="alternativeHeadline"
+          className={[
+            ...generateClassNameList('ArticleTemplate--title'),
+            ...extendedHeaderItemClasses,
+          ].join(' ')}
+        >
+          <span
+            className={[
+              ...generateClassNameList('ArticleTemplate--title-uppercase'),
+              ...extendedHeaderItemClasses,
+            ].join(' ')}
+          >World In Numbers</span> Countries
+        </h1>
+        <div
+          className={[
+            ...generateClassNameList('ArticleTemplate--title-strap'),
+            ...extendedHeaderItemClasses,
+          ].join(' ')}
+        >
+          Our 2016 forecasts for 30 European countries.
+        </div>
+      </div>
+    );
+    return (
+      <ArticleHeaderContainer generateClassNameList={generateClassNameList}>
+        {titleEl}
+      </ArticleHeaderContainer>
+    );
+  }
+}

--- a/index.css
+++ b/index.css
@@ -3,12 +3,14 @@
 @import '@economist/component-ad-panel';
 @import '@economist/component-video';
 @import '@economist/component-win-stats-container';
+@import '@economist/component-palette';
 
-@import "./shared";
-@import "./main";
-@import "./portrait";
-@import "./leader";
-@import "./predictors";
+@import './shared';
+@import './main';
+@import './portrait';
+@import './leader';
+@import './predictors';
+@import './numbers';
 
 :root {
   --color-white: #fff;
@@ -19,6 +21,5 @@
   --color-red: #E3120B;
   --color-mid-blue: #367FB6;
   --color-dark-blue: #253A43;
-
   --color-imagecaption-text: #9c9c9c;
 }

--- a/numbers.css
+++ b/numbers.css
@@ -1,0 +1,62 @@
+.world-in-numbers-ArticleTemplate--title {
+  font-family: 'Officina';
+  font-size: 40px;
+  line-height: 52px;
+}
+
+.world-in-numbers-ArticleTemplate--title-uppercase {
+  text-transform: uppercase;
+  font-family: 'Georgia, serif';
+  font-weight: normal;
+}
+
+.world-in-numbers-ArticleTemplate--title-strap {
+  font-family: 'Officina';
+  margin-top: 37px;
+}
+
+.world-in-numbers-ArticleTemplate--header {
+  margin-bottom: 70px;
+}
+
+.world-in-numbers-ArticleTemplate--header,
+.world-in-numbers-ArticleTemplate--subheader {
+  text-align: center;
+}
+
+.world-in-numbers-ArticleTemplate--subheader {
+  margin: 0;
+  width: 100%;
+  border: 0 none;
+  border-bottom: 1px solid #979797;
+  padding: 0;
+  position: relative;
+  height: 41px;
+  margin-bottom: 70px;
+}
+
+.world-in-numbers-ArticleTemplate--section-section {
+  position: absolute;
+  left: 7.5%;
+  bottom: -1px;
+  margin: 0;
+  padding: 0;
+  font-size: 33px;
+  line-height: 40px;
+  color: var(--color-economist);
+  border-bottom: 1px solid var(--color-economist);
+}
+
+@media screen and (max-width: 860px) {
+  .world-in-numbers-ArticleTemplate--title {
+    font-size: 32px;
+    line-height: 43px;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .world-in-numbers-ArticleTemplate--title {
+    font-size: 28px;
+    line-height: 37px;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -129,11 +129,12 @@
   "dependencies": {
     "@economist/component-ad-panel": "^1.1.0",
     "@economist/component-articletemplate": "^8.0.0",
-    "@economist/component-win-stats-container": "^1.0.0",
     "@economist/component-imagecaption": "^2.0.0",
+    "@economist/component-palette": "^1.3.0",
     "@economist/component-picture": "^1.1.0",
     "@economist/component-variantify": "^1.0.1",
     "@economist/component-video": "^1.1.0",
+    "@economist/component-win-stats-container": "^1.0.0",
     "map-props": "^1.0.0",
     "react": "^0.14.3"
   },

--- a/subheader.es6
+++ b/subheader.es6
@@ -105,3 +105,35 @@ export class WinLeaderSubheader extends Component {
     );
   }
 }
+
+export class WinNumbersSubheader extends Component {
+  static get propTypes() {
+    return {
+      generateClassNameList: PropTypes.func,
+      title: PropTypes.string,
+    };
+  }
+
+  static get defaultProps() {
+    return {
+      generateClassNameList: defaultGenerateClassNameList,
+    };
+  }
+
+  render() {
+    const { generateClassNameList, title } = this.props;
+    return (
+      <ArticleSubheaderContainer generateClassNameList={generateClassNameList}>
+        <h2
+          itemProp="section"
+          className={[
+            ...generateClassNameList('ArticleTemplate--section-section'),
+            ...extendedSubheaderItemClasses,
+          ].join(' ')}
+        >
+          {title}
+        </h2>
+      </ArticleSubheaderContainer>
+    );
+  }
+}

--- a/variant-article.es6
+++ b/variant-article.es6
@@ -2,8 +2,8 @@
 import ArticleTemplate from '@economist/component-articletemplate';
 import createVariantSwitcher from '@economist/component-variantify';
 
-import { WinHeader, WinPredictorsHeader } from './header';
-import { WinSubheader, WinLeaderSubheader } from './subheader';
+import { WinHeader, WinPredictorsHeader, WinNumbersHeader } from './header';
+import { WinSubheader, WinLeaderSubheader, WinNumbersSubheader } from './subheader';
 import {
   StandardArticleBody as StandardWinArticleBody,
   WorldInNumbersArticleBody as WorldInNumbersWinArticleBody,
@@ -38,10 +38,9 @@ const config = {
       ArticleFooter: WinFooter,
     },
     'world-in-numbers': {
-      ArticleHeader: WinHeader,
-      ArticleSubheader: WinSubheader,
+      ArticleHeader: WinNumbersHeader,
+      ArticleSubheader: WinNumbersSubheader,
       ArticleBody: WorldInNumbersWinArticleBody,
-      ArticleFooter: WinFooter,
     },
   },
 };


### PR DESCRIPTION
This is first round to get something on stage for Alex to look at.

Relies on https://github.com/economist-components/component-win-stats-container/pull/2