### PR TITLE
Fixes for mobile app call to action on article pages

### DIFF
--- a/cta.es6
+++ b/cta.es6
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export default function CallToAction({
-  generateClassNameList,
+  generateClassNameList = (defaultClass) => (defaultClass),
 }) {
   return (
     <div

--- a/main.css
+++ b/main.css
@@ -46,8 +46,8 @@ article:not(.world-in-portrait-ArticleTemplate--container) .ArticleTemplate--app
 }
 
 .app-cta {
-  margin: 70px 7.5%;
-  padding: 30px 0;
+  margin: 70px 7.5% 0 7.5%;
+  padding: 30px 0 70px 30px;
   max-width: 1090px;
   line-height: 0;
 }


### PR DESCRIPTION
Provides default when generateClassNameList is not passed from parent
Removes 70px margin so alignment of gradient on the CTA on predictors template lines up with the footer.